### PR TITLE
Validate TypeScript 7 with typecheck CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,13 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
       - run: bun run fmt:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - run: bun install --frozen-lockfile
+      - run: bunx tsc --noEmit

--- a/bun.lock
+++ b/bun.lock
@@ -10,9 +10,10 @@
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "oxlint-tsgolint": "0.25.0",
+        "typescript": "7.0.2",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "google/diarization": {
@@ -24,7 +25,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "google/embedding": {
@@ -37,7 +38,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "google/image": {
@@ -49,7 +50,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "google/transcription": {
@@ -61,7 +62,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "google/tts": {
@@ -73,7 +74,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "google/video": {
@@ -85,7 +86,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "openai/diarization": {
@@ -97,7 +98,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "openai/image": {
@@ -109,7 +110,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "openai/transcription": {
@@ -121,7 +122,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
     "openai/video": {
@@ -133,7 +134,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0",
+        "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
   },
@@ -279,6 +280,46 @@
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -452,7 +493,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "typical": ["typical@4.0.0", "", {}, "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "typescript": "7.0.2",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "google/diarization": {
@@ -25,7 +25,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "google/embedding": {
@@ -38,7 +38,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "google/image": {
@@ -50,7 +50,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "google/transcription": {
@@ -62,7 +62,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "google/tts": {
@@ -74,7 +74,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "google/video": {
@@ -86,7 +86,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "openai/diarization": {
@@ -98,7 +98,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "openai/image": {
@@ -110,7 +110,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "openai/transcription": {
@@ -122,7 +122,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
     "openai/video": {
@@ -134,7 +134,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6.0.0 || ^7.0.0",
+        "typescript": "^7.0.0",
       },
     },
   },

--- a/google/diarization/package.json
+++ b/google/diarization/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/google/diarization/package.json
+++ b/google/diarization/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/google/embedding/package.json
+++ b/google/embedding/package.json
@@ -11,6 +11,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/google/embedding/package.json
+++ b/google/embedding/package.json
@@ -11,6 +11,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/google/image/package.json
+++ b/google/image/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/google/image/package.json
+++ b/google/image/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/google/transcription/package.json
+++ b/google/transcription/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/google/transcription/package.json
+++ b/google/transcription/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/google/tts/package.json
+++ b/google/tts/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/google/tts/package.json
+++ b/google/tts/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/google/video/package.json
+++ b/google/video/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/google/video/package.json
+++ b/google/video/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/openai/diarization/package.json
+++ b/openai/diarization/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/openai/diarization/package.json
+++ b/openai/diarization/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/openai/image/package.json
+++ b/openai/image/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/openai/image/package.json
+++ b/openai/image/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/openai/transcription/package.json
+++ b/openai/transcription/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/openai/transcription/package.json
+++ b/openai/transcription/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/openai/video/package.json
+++ b/openai/video/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/openai/video/package.json
+++ b/openai/video/package.json
@@ -10,6 +10,6 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "typescript": "7.0.2"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0 || ^7.0.0"
+    "typescript": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "bun-types": "1.3.14",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
-    "oxlint-tsgolint": "0.25.0"
+    "oxlint-tsgolint": "0.25.0",
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6.0.0"
+    "typescript": "^5 || ^6.0.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- move the repository to TypeScript 7-only peer dependency support
- pin TypeScript 7.0.2 as the development compiler so CI actually validates TypeScript 7
- add a normal CI typecheck job using the existing root tsconfig

## Validation

- bun install --frozen-lockfile
- bun run lint
- bun run fmt:check
- bunx tsc --noEmit (TypeScript 7.0.2)
- pinact run --check
- zizmor --format github .

No test files or build script/configuration exist, so test and build are not added.