### PR TITLE
Run independent CI checks in parallel

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -25,12 +25,13 @@ jobs:
         with:
           aqua_version: v2.61.0
 
-      - name: Check action pinning
-        run: pinact run --check
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - parallel:
+          - name: Check action pinning
+            run: pinact run --check
+            env:
+              GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Audit workflows
-        run: zizmor --format github .
-        env:
-          GH_TOKEN: ${{ github.token }}
+          - name: Audit workflows
+            run: zizmor --format github .
+            env:
+              GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,8 @@ jobs:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
-      - run: bun run lint
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      - run: bun install --frozen-lockfile
-      - run: bun run fmt:check
+      - parallel:
+          - name: Lint
+            run: bun run lint
+          - name: Check format
+            run: bun run fmt:check


### PR DESCRIPTION
## Summary

- consolidate lint and format jobs that use the same Bun setup
- run those independent checks in a single `parallel:` group
- run pinact and zizmor in parallel
- preserve the stable tsgo migration from the latest `main` without restoring the removed standalone typecheck job

## Verification

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run fmt:check`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`